### PR TITLE
Specified prettier as a peer dependency of ember-template-lint

### DIFF
--- a/.changeset/mighty-walls-watch.md
+++ b/.changeset/mighty-walls-watch.md
@@ -1,0 +1,5 @@
+---
+"my-v2-addon": patch
+---
+
+Consumed the correct configuration

--- a/.changeset/serious-islands-watch.md
+++ b/.changeset/serious-islands-watch.md
@@ -1,0 +1,5 @@
+---
+"@ijlee2-frontend-configs/ember-template-lint": patch
+---
+
+Specified prettier as a peer dependency

--- a/packages/ember-template-lint/package.json
+++ b/packages/ember-template-lint/package.json
@@ -23,10 +23,14 @@
     "prettier": "^3.5.1"
   },
   "peerDependencies": {
-    "ember-template-lint": "^6.0.0"
+    "ember-template-lint": "^6.0.0",
+    "prettier": "^3.0.0"
   },
   "peerDependenciesMeta": {
     "ember-template-lint": {
+      "optional": false
+    },
+    "prettier": {
       "optional": false
     }
   },

--- a/tests/my-v2-addon/.stylelintrc.mjs
+++ b/tests/my-v2-addon/.stylelintrc.mjs
@@ -1,1 +1,1 @@
-export { default } from '@ijlee2-frontend-configs/stylelint';
+export { default } from '@ijlee2-frontend-configs/stylelint/css-modules';


### PR DESCRIPTION
## Background

`@ijlee2-frontend-configs/ember-template-lint`, which depends on `ember-template-lint-plugin-prettier`, requires `prettier`. This is mentioned in the [`README`](https://github.com/ijlee2/frontend-configs/blob/0.4.3/packages/ember-template-lint/README.md), but I didn't add `prettier` to `peerDependencies` in `package.json`.
