### PR TITLE
Sorted class members

### DIFF
--- a/.changeset/fancy-bats-agree.md
+++ b/.changeset/fancy-bats-agree.md
@@ -1,0 +1,6 @@
+---
+"@ijlee2-frontend-configs/eslint-config-ember": minor
+"@ijlee2-frontend-configs/eslint-config-node": minor
+---
+
+Sorted class members

--- a/packages/eslint/ember/package.json
+++ b/packages/eslint/ember/package.json
@@ -33,6 +33,7 @@
     "eslint-plugin-prettier": "^5.2.6",
     "eslint-plugin-qunit": "^8.1.2",
     "eslint-plugin-simple-import-sort": "^12.1.1",
+    "eslint-plugin-sort-class-members": "^1.21.0",
     "eslint-plugin-typescript-sort-keys": "^3.3.0",
     "globals": "^16.0.0",
     "typescript-eslint": "^8.31.1"

--- a/packages/eslint/ember/v1-addon/index.mjs
+++ b/packages/eslint/ember/v1-addon/index.mjs
@@ -6,6 +6,7 @@ import eslintPluginN from 'eslint-plugin-n';
 import eslintPluginPrettier from 'eslint-plugin-prettier/recommended';
 import eslintPluginQunit from 'eslint-plugin-qunit';
 import eslintPluginSimpleImportSort from 'eslint-plugin-simple-import-sort';
+import eslintPluginSortClassMembers from 'eslint-plugin-sort-class-members';
 import eslintPluginTypescriptSortKeys from 'eslint-plugin-typescript-sort-keys';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
@@ -47,6 +48,7 @@ export default tseslint.config(
   eslintPluginEmber.configs.base,
   eslintPluginEmber.configs.gjs,
   eslintPluginImportX.flatConfigs.recommended,
+  eslintPluginSortClassMembers.configs['flat/recommended'],
   eslintPluginPrettier,
   {
     plugins: {
@@ -59,6 +61,72 @@ export default tseslint.config(
       'max-depth': ['error', 4],
       'simple-import-sort/imports': 'error',
       'simple-import-sort/exports': 'error',
+      'sort-class-members/sort-class-members': [
+        2,
+        {
+          groups: {
+            'ember-actions': [
+              {
+                groupByDecorator: 'action',
+                sort: 'alphabetical',
+                type: 'method',
+              },
+            ],
+            'ember-data-decorators': [
+              {
+                groupByDecorator: 'belongsTo',
+                sort: 'alphabetical',
+                type: 'property',
+              },
+              {
+                groupByDecorator: 'hasMany',
+                sort: 'alphabetical',
+                type: 'property',
+              },
+              {
+                groupByDecorator: 'attr',
+                sort: 'alphabetical',
+                type: 'property',
+              },
+            ],
+            'ember-controller-model': [{ name: 'model', type: 'property' }],
+            'ember-controller-queryParams': [
+              { name: 'queryParams', type: 'property' },
+            ],
+            'ember-services': [
+              {
+                groupByDecorator: 'service',
+                sort: 'alphabetical',
+                type: 'property',
+              },
+            ],
+            'ember-tracked-properties': [
+              {
+                groupByDecorator: 'tracked',
+                sort: 'alphabetical',
+                type: 'property',
+              },
+            ],
+            getters: [{ kind: 'get', sort: 'alphabetical' }],
+            methods: [{ sort: 'alphabetical', type: 'method' }],
+            properties: [{ sort: 'alphabetical', type: 'property' }],
+            setters: [{ kind: 'set', sort: 'alphabetical' }],
+          },
+          order: [
+            '[ember-data-decorators]',
+            '[ember-services]',
+            '[ember-controller-model]',
+            '[ember-controller-queryParams]',
+            '[properties]',
+            '[ember-tracked-properties]',
+            '[getters]',
+            '[setters]',
+            'constructor',
+            '[methods]',
+            '[ember-actions]',
+          ],
+        },
+      ],
     },
   },
 

--- a/packages/eslint/ember/v1-app/index.mjs
+++ b/packages/eslint/ember/v1-app/index.mjs
@@ -6,6 +6,7 @@ import eslintPluginN from 'eslint-plugin-n';
 import eslintPluginPrettier from 'eslint-plugin-prettier/recommended';
 import eslintPluginQunit from 'eslint-plugin-qunit';
 import eslintPluginSimpleImportSort from 'eslint-plugin-simple-import-sort';
+import eslintPluginSortClassMembers from 'eslint-plugin-sort-class-members';
 import eslintPluginTypescriptSortKeys from 'eslint-plugin-typescript-sort-keys';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
@@ -47,6 +48,7 @@ export default tseslint.config(
   eslintPluginEmber.configs.base,
   eslintPluginEmber.configs.gjs,
   eslintPluginImportX.flatConfigs.recommended,
+  eslintPluginSortClassMembers.configs['flat/recommended'],
   eslintPluginPrettier,
   {
     plugins: {
@@ -59,6 +61,72 @@ export default tseslint.config(
       'max-depth': ['error', 4],
       'simple-import-sort/imports': 'error',
       'simple-import-sort/exports': 'error',
+      'sort-class-members/sort-class-members': [
+        2,
+        {
+          groups: {
+            'ember-actions': [
+              {
+                groupByDecorator: 'action',
+                sort: 'alphabetical',
+                type: 'method',
+              },
+            ],
+            'ember-data-decorators': [
+              {
+                groupByDecorator: 'belongsTo',
+                sort: 'alphabetical',
+                type: 'property',
+              },
+              {
+                groupByDecorator: 'hasMany',
+                sort: 'alphabetical',
+                type: 'property',
+              },
+              {
+                groupByDecorator: 'attr',
+                sort: 'alphabetical',
+                type: 'property',
+              },
+            ],
+            'ember-controller-model': [{ name: 'model', type: 'property' }],
+            'ember-controller-queryParams': [
+              { name: 'queryParams', type: 'property' },
+            ],
+            'ember-services': [
+              {
+                groupByDecorator: 'service',
+                sort: 'alphabetical',
+                type: 'property',
+              },
+            ],
+            'ember-tracked-properties': [
+              {
+                groupByDecorator: 'tracked',
+                sort: 'alphabetical',
+                type: 'property',
+              },
+            ],
+            getters: [{ kind: 'get', sort: 'alphabetical' }],
+            methods: [{ sort: 'alphabetical', type: 'method' }],
+            properties: [{ sort: 'alphabetical', type: 'property' }],
+            setters: [{ kind: 'set', sort: 'alphabetical' }],
+          },
+          order: [
+            '[ember-data-decorators]',
+            '[ember-services]',
+            '[ember-controller-model]',
+            '[ember-controller-queryParams]',
+            '[properties]',
+            '[ember-tracked-properties]',
+            '[getters]',
+            '[setters]',
+            'constructor',
+            '[methods]',
+            '[ember-actions]',
+          ],
+        },
+      ],
     },
   },
 

--- a/packages/eslint/ember/v2-addon/index.mjs
+++ b/packages/eslint/ember/v2-addon/index.mjs
@@ -5,6 +5,7 @@ import eslintPluginImportX from 'eslint-plugin-import-x';
 import eslintPluginN from 'eslint-plugin-n';
 import eslintPluginPrettier from 'eslint-plugin-prettier/recommended';
 import eslintPluginSimpleImportSort from 'eslint-plugin-simple-import-sort';
+import eslintPluginSortClassMembers from 'eslint-plugin-sort-class-members';
 import eslintPluginTypescriptSortKeys from 'eslint-plugin-typescript-sort-keys';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
@@ -36,6 +37,7 @@ export default tseslint.config(
   eslintPluginEmber.configs.base,
   eslintPluginEmber.configs.gjs,
   eslintPluginImportX.flatConfigs.recommended,
+  eslintPluginSortClassMembers.configs['flat/recommended'],
   eslintPluginPrettier,
   {
     plugins: {
@@ -48,6 +50,72 @@ export default tseslint.config(
       'max-depth': ['error', 4],
       'simple-import-sort/imports': 'error',
       'simple-import-sort/exports': 'error',
+      'sort-class-members/sort-class-members': [
+        2,
+        {
+          groups: {
+            'ember-actions': [
+              {
+                groupByDecorator: 'action',
+                sort: 'alphabetical',
+                type: 'method',
+              },
+            ],
+            'ember-data-decorators': [
+              {
+                groupByDecorator: 'belongsTo',
+                sort: 'alphabetical',
+                type: 'property',
+              },
+              {
+                groupByDecorator: 'hasMany',
+                sort: 'alphabetical',
+                type: 'property',
+              },
+              {
+                groupByDecorator: 'attr',
+                sort: 'alphabetical',
+                type: 'property',
+              },
+            ],
+            'ember-controller-model': [{ name: 'model', type: 'property' }],
+            'ember-controller-queryParams': [
+              { name: 'queryParams', type: 'property' },
+            ],
+            'ember-services': [
+              {
+                groupByDecorator: 'service',
+                sort: 'alphabetical',
+                type: 'property',
+              },
+            ],
+            'ember-tracked-properties': [
+              {
+                groupByDecorator: 'tracked',
+                sort: 'alphabetical',
+                type: 'property',
+              },
+            ],
+            getters: [{ kind: 'get', sort: 'alphabetical' }],
+            methods: [{ sort: 'alphabetical', type: 'method' }],
+            properties: [{ sort: 'alphabetical', type: 'property' }],
+            setters: [{ kind: 'set', sort: 'alphabetical' }],
+          },
+          order: [
+            '[ember-data-decorators]',
+            '[ember-services]',
+            '[ember-controller-model]',
+            '[ember-controller-queryParams]',
+            '[properties]',
+            '[ember-tracked-properties]',
+            '[getters]',
+            '[setters]',
+            'constructor',
+            '[methods]',
+            '[ember-actions]',
+          ],
+        },
+      ],
     },
   },
 

--- a/packages/eslint/ember/v2-app/index.mjs
+++ b/packages/eslint/ember/v2-app/index.mjs
@@ -6,6 +6,7 @@ import eslintPluginN from 'eslint-plugin-n';
 import eslintPluginPrettier from 'eslint-plugin-prettier/recommended';
 import eslintPluginQunit from 'eslint-plugin-qunit';
 import eslintPluginSimpleImportSort from 'eslint-plugin-simple-import-sort';
+import eslintPluginSortClassMembers from 'eslint-plugin-sort-class-members';
 import eslintPluginTypescriptSortKeys from 'eslint-plugin-typescript-sort-keys';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
@@ -37,6 +38,7 @@ export default tseslint.config(
   eslintPluginEmber.configs.base,
   eslintPluginEmber.configs.gjs,
   eslintPluginImportX.flatConfigs.recommended,
+  eslintPluginSortClassMembers.configs['flat/recommended'],
   eslintPluginPrettier,
   {
     plugins: {
@@ -49,6 +51,72 @@ export default tseslint.config(
       'max-depth': ['error', 4],
       'simple-import-sort/imports': 'error',
       'simple-import-sort/exports': 'error',
+      'sort-class-members/sort-class-members': [
+        2,
+        {
+          groups: {
+            'ember-actions': [
+              {
+                groupByDecorator: 'action',
+                sort: 'alphabetical',
+                type: 'method',
+              },
+            ],
+            'ember-data-decorators': [
+              {
+                groupByDecorator: 'belongsTo',
+                sort: 'alphabetical',
+                type: 'property',
+              },
+              {
+                groupByDecorator: 'hasMany',
+                sort: 'alphabetical',
+                type: 'property',
+              },
+              {
+                groupByDecorator: 'attr',
+                sort: 'alphabetical',
+                type: 'property',
+              },
+            ],
+            'ember-controller-model': [{ name: 'model', type: 'property' }],
+            'ember-controller-queryParams': [
+              { name: 'queryParams', type: 'property' },
+            ],
+            'ember-services': [
+              {
+                groupByDecorator: 'service',
+                sort: 'alphabetical',
+                type: 'property',
+              },
+            ],
+            'ember-tracked-properties': [
+              {
+                groupByDecorator: 'tracked',
+                sort: 'alphabetical',
+                type: 'property',
+              },
+            ],
+            getters: [{ kind: 'get', sort: 'alphabetical' }],
+            methods: [{ sort: 'alphabetical', type: 'method' }],
+            properties: [{ sort: 'alphabetical', type: 'property' }],
+            setters: [{ kind: 'set', sort: 'alphabetical' }],
+          },
+          order: [
+            '[ember-data-decorators]',
+            '[ember-services]',
+            '[ember-controller-model]',
+            '[ember-controller-queryParams]',
+            '[properties]',
+            '[ember-tracked-properties]',
+            '[getters]',
+            '[setters]',
+            'constructor',
+            '[methods]',
+            '[ember-actions]',
+          ],
+        },
+      ],
     },
   },
 

--- a/packages/eslint/node/javascript/index.mjs
+++ b/packages/eslint/node/javascript/index.mjs
@@ -4,6 +4,7 @@ import eslintPluginImportX from 'eslint-plugin-import-x';
 import eslintPluginN from 'eslint-plugin-n';
 import eslintPluginPrettier from 'eslint-plugin-prettier/recommended';
 import eslintPluginSimpleImportSort from 'eslint-plugin-simple-import-sort';
+import eslintPluginSortClassMembers from 'eslint-plugin-sort-class-members';
 import globals from 'globals';
 
 const parserOptionsJs = {
@@ -26,6 +27,7 @@ export default [
 
   eslint.configs.recommended,
   eslintPluginImportX.flatConfigs.recommended,
+  eslintPluginSortClassMembers.configs['flat/recommended'],
   eslintPluginPrettier,
   {
     plugins: {
@@ -38,6 +40,24 @@ export default [
       'max-depth': ['error', 4],
       'simple-import-sort/imports': 'error',
       'simple-import-sort/exports': 'error',
+      'sort-class-members/sort-class-members': [
+        2,
+        {
+          groups: {
+            getters: [{ kind: 'get', sort: 'alphabetical' }],
+            methods: [{ sort: 'alphabetical', type: 'method' }],
+            properties: [{ sort: 'alphabetical', type: 'property' }],
+            setters: [{ kind: 'set', sort: 'alphabetical' }],
+          },
+          order: [
+            '[properties]',
+            '[getters]',
+            '[setters]',
+            'constructor',
+            '[methods]',
+          ],
+        },
+      ],
     },
   },
 

--- a/packages/eslint/node/package.json
+++ b/packages/eslint/node/package.json
@@ -28,6 +28,7 @@
     "eslint-plugin-n": "^17.17.0",
     "eslint-plugin-prettier": "^5.2.6",
     "eslint-plugin-simple-import-sort": "^12.1.1",
+    "eslint-plugin-sort-class-members": "^1.21.0",
     "eslint-plugin-typescript-sort-keys": "^3.3.0",
     "globals": "^16.0.0",
     "typescript-eslint": "^8.31.1"

--- a/packages/eslint/node/typescript/index.mjs
+++ b/packages/eslint/node/typescript/index.mjs
@@ -4,6 +4,7 @@ import eslintPluginImportX from 'eslint-plugin-import-x';
 import eslintPluginN from 'eslint-plugin-n';
 import eslintPluginPrettier from 'eslint-plugin-prettier/recommended';
 import eslintPluginSimpleImportSort from 'eslint-plugin-simple-import-sort';
+import eslintPluginSortClassMembers from 'eslint-plugin-sort-class-members';
 import eslintPluginTypescriptSortKeys from 'eslint-plugin-typescript-sort-keys';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
@@ -33,6 +34,7 @@ export default tseslint.config(
 
   eslint.configs.recommended,
   eslintPluginImportX.flatConfigs.recommended,
+  eslintPluginSortClassMembers.configs['flat/recommended'],
   eslintPluginPrettier,
   {
     plugins: {
@@ -45,6 +47,24 @@ export default tseslint.config(
       'max-depth': ['error', 4],
       'simple-import-sort/imports': 'error',
       'simple-import-sort/exports': 'error',
+      'sort-class-members/sort-class-members': [
+        2,
+        {
+          groups: {
+            getters: [{ kind: 'get', sort: 'alphabetical' }],
+            methods: [{ sort: 'alphabetical', type: 'method' }],
+            properties: [{ sort: 'alphabetical', type: 'property' }],
+            setters: [{ kind: 'set', sort: 'alphabetical' }],
+          },
+          order: [
+            '[properties]',
+            '[getters]',
+            '[setters]',
+            'constructor',
+            '[methods]',
+          ],
+        },
+      ],
     },
   },
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       eslint-plugin-simple-import-sort:
         specifier: ^12.1.1
         version: 12.1.1(eslint@9.25.1(jiti@1.21.7))
+      eslint-plugin-sort-class-members:
+        specifier: ^1.21.0
+        version: 1.21.0(eslint@9.25.1(jiti@1.21.7))
       eslint-plugin-typescript-sort-keys:
         specifier: ^3.3.0
         version: 3.3.0(@typescript-eslint/parser@8.31.1(eslint@9.25.1(jiti@1.21.7))(typescript@5.8.3))(eslint@9.25.1(jiti@1.21.7))(typescript@5.8.3)
@@ -127,6 +130,9 @@ importers:
       eslint-plugin-simple-import-sort:
         specifier: ^12.1.1
         version: 12.1.1(eslint@9.25.1(jiti@1.21.7))
+      eslint-plugin-sort-class-members:
+        specifier: ^1.21.0
+        version: 1.21.0(eslint@9.25.1(jiti@1.21.7))
       eslint-plugin-typescript-sort-keys:
         specifier: ^3.3.0
         version: 3.3.0(@typescript-eslint/parser@8.31.1(eslint@9.25.1(jiti@1.21.7))(typescript@5.8.3))(eslint@9.25.1(jiti@1.21.7))(typescript@5.8.3)
@@ -4396,6 +4402,12 @@ packages:
     resolution: {integrity: sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==}
     peerDependencies:
       eslint: '>=5.0.0'
+
+  eslint-plugin-sort-class-members@1.21.0:
+    resolution: {integrity: sha512-QKV4jvGMu/ge1l4s1TUBC6rqqV/fbABWY7q2EeNpV3FRikoX6KuLhiNvS8UuMi+EERe0hKGrNU9e6ukFDxNnZQ==}
+    engines: {node: '>=4.0.0'}
+    peerDependencies:
+      eslint: '>=0.8.0'
 
   eslint-plugin-typescript-sort-keys@3.3.0:
     resolution: {integrity: sha512-bRW3Rc/VNdrSP9OoY5wgjjaXCOOkZKpzvl/Mk6l8Sg8CMehVIcg9K4y33l+ZcZiknpl0aR6rKusxuCJNGZWmVw==}
@@ -13466,6 +13478,10 @@ snapshots:
       - eslint
 
   eslint-plugin-simple-import-sort@12.1.1(eslint@9.25.1(jiti@1.21.7)):
+    dependencies:
+      eslint: 9.25.1(jiti@1.21.7)
+
+  eslint-plugin-sort-class-members@1.21.0(eslint@9.25.1(jiti@1.21.7)):
     dependencies:
       eslint: 9.25.1(jiti@1.21.7)
 


### PR DESCRIPTION
## Background

We can use [`eslint-plugin-sort-class-members`](https://github.com/bryanrsmith/eslint-plugin-sort-class-members) to ensure more consistency in Ember projects (e.g. components, controllers, models, services, routes). I didn't specify rules for classic Ember to ease maintenance.
