### PR TITLE
Updated rules

### DIFF
--- a/.changeset/large-results-poke.md
+++ b/.changeset/large-results-poke.md
@@ -1,0 +1,5 @@
+---
+"@ijlee2-frontend-configs/eslint-config-ember": minor
+---
+
+Placed services and tracked properties nearer one another

--- a/.changeset/new-teams-shave.md
+++ b/.changeset/new-teams-shave.md
@@ -1,0 +1,5 @@
+---
+"@ijlee2-frontend-configs/ember-template-lint": minor
+---
+
+Enabled sort-invocations

--- a/packages/ember-template-lint/index.cjs
+++ b/packages/ember-template-lint/index.cjs
@@ -3,6 +3,9 @@
 module.exports = {
   plugins: ['ember-template-lint-plugin-prettier'],
   extends: ['recommended', 'ember-template-lint-plugin-prettier:recommended'],
+  rules: {
+    'sort-invocations': true,
+  },
   overrides: [
     {
       files: ['**/*.{gjs,gts}'],

--- a/packages/ember-template-lint/package.json
+++ b/packages/ember-template-lint/package.json
@@ -24,7 +24,7 @@
     "prettier": "^3.5.3"
   },
   "peerDependencies": {
-    "ember-template-lint": "^7.0.0",
+    "ember-template-lint": "^7.7.0",
     "prettier": "^3.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/eslint/ember/v1-addon/index.mjs
+++ b/packages/eslint/ember/v1-addon/index.mjs
@@ -114,11 +114,11 @@ export default tseslint.config(
           },
           order: [
             '[ember-data-decorators]',
-            '[ember-services]',
             '[ember-controller-model]',
             '[ember-controller-queryParams]',
-            '[properties]',
+            '[ember-services]',
             '[ember-tracked-properties]',
+            '[properties]',
             '[getters]',
             '[setters]',
             'constructor',

--- a/packages/eslint/ember/v1-app/index.mjs
+++ b/packages/eslint/ember/v1-app/index.mjs
@@ -114,11 +114,11 @@ export default tseslint.config(
           },
           order: [
             '[ember-data-decorators]',
-            '[ember-services]',
             '[ember-controller-model]',
             '[ember-controller-queryParams]',
-            '[properties]',
+            '[ember-services]',
             '[ember-tracked-properties]',
+            '[properties]',
             '[getters]',
             '[setters]',
             'constructor',

--- a/packages/eslint/ember/v2-addon/index.mjs
+++ b/packages/eslint/ember/v2-addon/index.mjs
@@ -103,11 +103,11 @@ export default tseslint.config(
           },
           order: [
             '[ember-data-decorators]',
-            '[ember-services]',
             '[ember-controller-model]',
             '[ember-controller-queryParams]',
-            '[properties]',
+            '[ember-services]',
             '[ember-tracked-properties]',
+            '[properties]',
             '[getters]',
             '[setters]',
             'constructor',

--- a/packages/eslint/ember/v2-app/index.mjs
+++ b/packages/eslint/ember/v2-app/index.mjs
@@ -104,11 +104,11 @@ export default tseslint.config(
           },
           order: [
             '[ember-data-decorators]',
-            '[ember-services]',
             '[ember-controller-model]',
             '[ember-controller-queryParams]',
-            '[properties]',
+            '[ember-services]',
             '[ember-tracked-properties]',
+            '[properties]',
             '[getters]',
             '[setters]',
             'constructor',


### PR DESCRIPTION
## Background

When reading a file for the first time, services and tracked properties should be more prominently shown (towards the top of the file).
