### PR TITLE
Sorted ember-data's Type brand

### DIFF
--- a/.changeset/wet-towns-open.md
+++ b/.changeset/wet-towns-open.md
@@ -1,0 +1,5 @@
+---
+"@ijlee2-frontend-configs/eslint-config-ember": minor
+---
+
+Sorted ember-data's Type brand

--- a/packages/eslint/ember/custom-rules/sort-class-members.mjs
+++ b/packages/eslint/ember/custom-rules/sort-class-members.mjs
@@ -9,6 +9,10 @@ export default [
           type: 'method',
         },
       ],
+      'ember-controller-model': [{ name: 'model', type: 'property' }],
+      'ember-controller-queryParams': [
+        { name: 'queryParams', type: 'property' },
+      ],
       'ember-data-decorators': [
         {
           groupByDecorator: 'belongsTo',
@@ -25,10 +29,6 @@ export default [
           sort: 'alphabetical',
           type: 'property',
         },
-      ],
-      'ember-controller-model': [{ name: 'model', type: 'property' }],
-      'ember-controller-queryParams': [
-        { name: 'queryParams', type: 'property' },
       ],
       'ember-services': [
         {

--- a/packages/eslint/ember/custom-rules/sort-class-members.mjs
+++ b/packages/eslint/ember/custom-rules/sort-class-members.mjs
@@ -30,6 +30,12 @@ export default [
           type: 'property',
         },
       ],
+      'ember-data-type-brand': [
+        {
+          name: 'Type',
+          type: 'property',
+        },
+      ],
       'ember-services': [
         {
           groupByDecorator: 'service',
@@ -50,6 +56,7 @@ export default [
       setters: [{ kind: 'set', sort: 'alphabetical' }],
     },
     order: [
+      '[ember-data-type-brand]',
       '[ember-data-decorators]',
       '[ember-controller-model]',
       '[ember-controller-queryParams]',


### PR DESCRIPTION
## Background

`ember-data` and `@warp-drive` models need to define the `Type` brand in TypeScript projects. It's best to list the identifier on top.

```ts
import Model, { attr } from '@ember-data/model';
import { Type } from '@warp-drive/core-types/symbols';

export default class User extends Model {
  [Type] = 'user' as const;

  @attr declare name: string;
}
```

```ts
import Model, { attr } from '@ember-data/model';
import type { Type } from '@warp-drive/core-types/symbols';

export default class User extends Model {
  declare [Type]: 'user';

  @attr declare name: string;
}
```

https://github.com/emberjs/data/blob/v5.4.1/guides/typescript/3-typing-models.md#type