### PR TITLE
Enabled recommended configs from eslint-plugin-n and eslint-plugin-qunit

### DIFF
--- a/.changeset/petite-pillows-join.md
+++ b/.changeset/petite-pillows-join.md
@@ -1,0 +1,5 @@
+---
+"@ijlee2-frontend-configs/eslint-config-node": minor
+---
+
+Enabled recommended configs from eslint-plugin-n

--- a/.changeset/poor-facts-draw.md
+++ b/.changeset/poor-facts-draw.md
@@ -1,0 +1,5 @@
+---
+"@ijlee2-frontend-configs/eslint-config-ember": minor
+---
+
+Enabled recommended configs from eslint-plugin-n and eslint-plugin-qunit

--- a/packages/eslint/ember/v1-addon/index.mjs
+++ b/packages/eslint/ember/v1-addon/index.mjs
@@ -33,6 +33,7 @@ const parserOptionsJs = {
 
 const parserOptionsTs = {
   projectService: true,
+  // eslint-disable-next-line n/no-unsupported-features/node-builtins
   tsconfigRootDir: import.meta.dirname,
 };
 

--- a/packages/eslint/ember/v1-addon/index.mjs
+++ b/packages/eslint/ember/v1-addon/index.mjs
@@ -121,6 +121,7 @@ export default tseslint.config(
 
   // Test files
   {
+    ...eslintPluginQunit.configs.recommended,
     files: ['tests/**/*-test.{gjs,gts,js,ts}'],
     plugins: {
       qunit: eslintPluginQunit,
@@ -129,6 +130,7 @@ export default tseslint.config(
 
   // Configuration files
   {
+    ...eslintPluginN.configs['flat/recommended-script'],
     files: [
       '**/*.cjs',
       'config/**/*.js',
@@ -150,6 +152,7 @@ export default tseslint.config(
     },
   },
   {
+    ...eslintPluginN.configs['flat/recommended-module'],
     files: ['**/*.mjs'],
     languageOptions: {
       ecmaVersion: 'latest',

--- a/packages/eslint/ember/v1-app/index.mjs
+++ b/packages/eslint/ember/v1-app/index.mjs
@@ -33,6 +33,7 @@ const parserOptionsJs = {
 
 const parserOptionsTs = {
   projectService: true,
+  // eslint-disable-next-line n/no-unsupported-features/node-builtins
   tsconfigRootDir: import.meta.dirname,
 };
 

--- a/packages/eslint/ember/v1-app/index.mjs
+++ b/packages/eslint/ember/v1-app/index.mjs
@@ -121,6 +121,7 @@ export default tseslint.config(
 
   // Test files
   {
+    ...eslintPluginQunit.configs.recommended,
     files: ['tests/**/*-test.{gjs,gts,js,ts}'],
     plugins: {
       qunit: eslintPluginQunit,
@@ -129,6 +130,7 @@ export default tseslint.config(
 
   // Configuration files
   {
+    ...eslintPluginN.configs['flat/recommended-script'],
     files: [
       '**/*.cjs',
       'config/**/*.js',
@@ -149,6 +151,7 @@ export default tseslint.config(
     },
   },
   {
+    ...eslintPluginN.configs['flat/recommended-module'],
     files: ['**/*.mjs'],
     languageOptions: {
       ecmaVersion: 'latest',

--- a/packages/eslint/ember/v2-addon/index.mjs
+++ b/packages/eslint/ember/v2-addon/index.mjs
@@ -22,6 +22,7 @@ const parserOptionsJs = {
 
 const parserOptionsTs = {
   projectService: true,
+  // eslint-disable-next-line n/no-unsupported-features/node-builtins
   tsconfigRootDir: import.meta.dirname,
 };
 

--- a/packages/eslint/ember/v2-addon/index.mjs
+++ b/packages/eslint/ember/v2-addon/index.mjs
@@ -122,6 +122,7 @@ export default tseslint.config(
 
   // Configuration files
   {
+    ...eslintPluginN.configs['flat/recommended-script'],
     files: [
       '**/*.cjs',
       '.prettierrc.js',
@@ -138,6 +139,7 @@ export default tseslint.config(
     },
   },
   {
+    ...eslintPluginN.configs['flat/recommended-module'],
     files: ['**/*.mjs'],
     languageOptions: {
       ecmaVersion: 'latest',

--- a/packages/eslint/ember/v2-app/index.mjs
+++ b/packages/eslint/ember/v2-app/index.mjs
@@ -111,6 +111,7 @@ export default tseslint.config(
 
   // Test files
   {
+    ...eslintPluginQunit.configs.recommended,
     files: ['tests/**/*-test.{gjs,gts,js,ts}'],
     plugins: {
       qunit: eslintPluginQunit,
@@ -119,6 +120,7 @@ export default tseslint.config(
 
   // Configuration files
   {
+    ...eslintPluginN.configs['flat/recommended-script'],
     files: [
       '**/*.cjs',
       'config/**/*.js',
@@ -139,6 +141,7 @@ export default tseslint.config(
     },
   },
   {
+    ...eslintPluginN.configs['flat/recommended-module'],
     files: ['**/*.mjs'],
     languageOptions: {
       ecmaVersion: 'latest',

--- a/packages/eslint/ember/v2-app/index.mjs
+++ b/packages/eslint/ember/v2-app/index.mjs
@@ -23,6 +23,7 @@ const parserOptionsJs = {
 
 const parserOptionsTs = {
   projectService: true,
+  // eslint-disable-next-line n/no-unsupported-features/node-builtins
   tsconfigRootDir: import.meta.dirname,
 };
 

--- a/packages/eslint/node/javascript/index.mjs
+++ b/packages/eslint/node/javascript/index.mjs
@@ -49,6 +49,7 @@ export default [
 
   // Configuration files
   {
+    ...eslintPluginN.configs['flat/recommended-script'],
     files: ['**/*.cjs'],
     languageOptions: {
       ecmaVersion: 'latest',
@@ -60,6 +61,7 @@ export default [
     },
   },
   {
+    ...eslintPluginN.configs['flat/recommended-module'],
     files: ['**/*.mjs'],
     languageOptions: {
       ecmaVersion: 'latest',

--- a/packages/eslint/node/typescript/index.mjs
+++ b/packages/eslint/node/typescript/index.mjs
@@ -21,6 +21,7 @@ const parserOptionsJs = {
 
 const parserOptionsTs = {
   projectService: true,
+  // eslint-disable-next-line n/no-unsupported-features/node-builtins
   tsconfigRootDir: import.meta.dirname,
 };
 

--- a/packages/eslint/node/typescript/index.mjs
+++ b/packages/eslint/node/typescript/index.mjs
@@ -85,6 +85,7 @@ export default tseslint.config(
 
   // Configuration files
   {
+    ...eslintPluginN.configs['flat/recommended-script'],
     files: ['**/*.cjs'],
     languageOptions: {
       ecmaVersion: 'latest',
@@ -96,6 +97,7 @@ export default tseslint.config(
     },
   },
   {
+    ...eslintPluginN.configs['flat/recommended-module'],
     files: ['**/*.mjs'],
     languageOptions: {
       ecmaVersion: 'latest',


### PR DESCRIPTION
## Background

Ember CLI's blueprints for the `eslint` config didn't enable the recommended configurations from `eslint-plugin-n` and `eslint-plugin-qunit`.

- https://github.com/ember-cli/ember-cli/issues/10660
- https://discord.com/channels/480462759797063690/486548111221719040/1377891963520548967


## References

- https://github.com/eslint-community/eslint-plugin-n/blob/v17.18.0/lib/index.js#L78-L79
- https://github.com/qunitjs/eslint-plugin-qunit/blob/v8.1.2/index.js#L22-L23
