### PR TITLE
Updated prettier-plugin-ember-hbs-tag to 1.0.0

### DIFF
--- a/.changeset/neat-tigers-rush.md
+++ b/.changeset/neat-tigers-rush.md
@@ -1,0 +1,5 @@
+---
+"@ijlee2-frontend-configs/prettier": patch
+---
+
+Updated prettier-plugin-ember-hbs-tag to 1.0.0

--- a/packages/prettier/package.json
+++ b/packages/prettier/package.json
@@ -17,7 +17,7 @@
     "lint:fix": "prettier \"**/*.mjs\" --cache --write"
   },
   "dependencies": {
-    "prettier-plugin-ember-hbs-tag": "^0.4.6",
+    "prettier-plugin-ember-hbs-tag": "^1.0.0",
     "prettier-plugin-ember-template-tag": "^2.1.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,8 +149,8 @@ importers:
   packages/prettier:
     dependencies:
       prettier-plugin-ember-hbs-tag:
-        specifier: ^0.4.6
-        version: 0.4.6(prettier@3.6.2)
+        specifier: ^1.0.0
+        version: 1.0.0(prettier@3.6.2)
       prettier-plugin-ember-template-tag:
         specifier: ^2.1.0
         version: 2.1.0(prettier@3.6.2)
@@ -6531,8 +6531,8 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier-plugin-ember-hbs-tag@0.4.6:
-    resolution: {integrity: sha512-2AvGEot3fYa7aG663rGG8vDAKronI93rlNld/lbHWV3qiGhfC33hVEO1EBkuVeqXcPr2/3LUM5Jt8yNRIqWkZA==}
+  prettier-plugin-ember-hbs-tag@1.0.0:
+    resolution: {integrity: sha512-erGe9vDfhjQoXjz+M9W7s3QDUpSsnR/TAdMhYntzEY9kIVut9rtdx33z+Vbw8VR6in/+vzb3mZVTAuCE5eWK+w==}
     engines: {node: 20.* || >= 22}
     peerDependencies:
       prettier: ^3.0.0
@@ -15170,7 +15170,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-ember-hbs-tag@0.4.6(prettier@3.6.2):
+  prettier-plugin-ember-hbs-tag@1.0.0(prettier@3.6.2):
     dependencies:
       '@babel/core': 7.28.0(supports-color@8.1.1)
       prettier: 3.6.2


### PR DESCRIPTION
`prettier-plugin-ember-hbs-tag` has been used in several production projects for a couple of months.