### PR TITLE
Replaced grip-gap (deprecated) with gap

### DIFF
--- a/.changeset/hot-showers-trade.md
+++ b/.changeset/hot-showers-trade.md
@@ -1,0 +1,5 @@
+---
+"@ijlee2-frontend-configs/stylelint": patch
+---
+
+Replaced grip-gap (deprecated) with gap

--- a/packages/stylelint/css-modules/index.mjs
+++ b/packages/stylelint/css-modules/index.mjs
@@ -20,7 +20,7 @@ export default {
     'declaration-block-no-redundant-longhand-properties': [
       true,
       {
-        ignoreShorthands: ['grid-gap', 'grid-template'],
+        ignoreShorthands: ['gap', 'grid-template'],
       },
     ],
 

--- a/packages/stylelint/default/index.mjs
+++ b/packages/stylelint/default/index.mjs
@@ -13,7 +13,7 @@ export default {
     'declaration-block-no-redundant-longhand-properties': [
       true,
       {
-        ignoreShorthands: ['grid-gap', 'grid-template'],
+        ignoreShorthands: ['gap', 'grid-template'],
       },
     ],
 

--- a/packages/stylelint/package.json
+++ b/packages/stylelint/package.json
@@ -25,7 +25,7 @@
     "prettier": "^3.6.2"
   },
   "peerDependencies": {
-    "stylelint": "^16.18.0"
+    "stylelint": "^16.23.0"
   },
   "peerDependenciesMeta": {
     "stylelint": {


### PR DESCRIPTION
## Background

Patches #50.

`stylelint@16.23.0` added the `property-no-deprecated` rule, which autofixes `grid-column-gap` and `grid-row-gap` to `column-gap` and `row-gap`, respectively. These changes, in return, cause `stylelint` to suggest using `gap`, which makes code less easily understandable. (Why I had made an exception for `grid-gap`.)