### PR TITLE
Enabled reportUnusedDisableDirectives

### DIFF
--- a/.changeset/sweet-squids-go.md
+++ b/.changeset/sweet-squids-go.md
@@ -1,0 +1,9 @@
+---
+"@ijlee2-frontend-configs/ember-template-lint": minor
+"my-v1-addon": patch
+"my-v2-addon": patch
+"my-v1-app": patch
+"my-v2-app": patch
+---
+
+Enabled reportUnusedDisableDirectives

--- a/packages/ember-template-lint/index.cjs
+++ b/packages/ember-template-lint/index.cjs
@@ -2,6 +2,7 @@
 
 module.exports = {
   extends: ['recommended'],
+  reportUnusedDisableDirectives: true,
   rules: {
     'sort-invocations': true,
   },

--- a/packages/ember-template-lint/package.json
+++ b/packages/ember-template-lint/package.json
@@ -18,7 +18,7 @@
     "prettier": "^3.6.2"
   },
   "peerDependencies": {
-    "ember-template-lint": "^7.9.1"
+    "ember-template-lint": "^7.9.2"
   },
   "peerDependenciesMeta": {
     "ember-template-lint": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,8 +346,8 @@ importers:
         specifier: ~6.6.0
         version: 6.6.0(@glimmer/component@2.0.0)(rsvp@4.8.5)
       ember-template-lint:
-        specifier: ^7.9.1
-        version: 7.9.1
+        specifier: ^7.9.2
+        version: 7.9.2
       ember-test-selectors:
         specifier: ^7.1.0
         version: 7.1.0
@@ -508,8 +508,8 @@ importers:
         specifier: ^4.3.0
         version: 4.3.0
       ember-template-lint:
-        specifier: 7.9.1
-        version: 7.9.1
+        specifier: 7.9.2
+        version: 7.9.2
       ember-test-selectors:
         specifier: ^7.1.0
         version: 7.1.0
@@ -632,8 +632,8 @@ importers:
         specifier: ~6.6.0
         version: 6.6.0(@glimmer/component@2.0.0)(rsvp@4.8.5)
       ember-template-lint:
-        specifier: ^7.9.1
-        version: 7.9.1
+        specifier: ^7.9.2
+        version: 7.9.2
       eslint:
         specifier: ^9.32.0
         version: 9.32.0(jiti@1.21.7)
@@ -797,8 +797,8 @@ importers:
         specifier: ^4.3.0
         version: 4.3.0
       ember-template-lint:
-        specifier: ^7.9.1
-        version: 7.9.1
+        specifier: ^7.9.2
+        version: 7.9.2
       ember-test-selectors:
         specifier: ^7.1.0
         version: 7.1.0
@@ -4155,8 +4155,8 @@ packages:
     resolution: {integrity: sha512-jZ5D6KLKU8up/AynZltmKh4lkXBPgTGSPgomprI/55XvIVqn42UNUpEz7ra/mO3QiGODDZOUesbggPe49i38sQ==}
     engines: {node: 16.* || >= 18}
 
-  ember-template-lint@7.9.1:
-    resolution: {integrity: sha512-uh5WU2sJKkQgDgIQovwv1D0fw2/RJnmyAHqIhaTYk68CfKQ/O5v31c1iXNu71qv3xeONi3QPl/rBW0EMdIFXWA==}
+  ember-template-lint@7.9.2:
+    resolution: {integrity: sha512-j2vt1laRRn1yipSrVm6+E2UbVrERTDoX/ye66Kc+FtI+W+SJSAuEPvMA+t2sofkqvP0u+TEg8Bc66YbShblAgg==}
     engines: {node: ^18.18.0 || >= 20.9.0}
     hasBin: true
 
@@ -12540,7 +12540,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-template-lint@7.9.1:
+  ember-template-lint@7.9.2:
     dependencies:
       '@lint-todo/utils': 13.1.1
       content-tag: 3.1.3

--- a/tests/my-v1-addon/package.json
+++ b/tests/my-v1-addon/package.json
@@ -85,7 +85,7 @@
     "ember-qunit": "^9.0.3",
     "ember-resolver": "^13.1.1",
     "ember-source": "~6.6.0",
-    "ember-template-lint": "^7.9.1",
+    "ember-template-lint": "^7.9.2",
     "ember-test-selectors": "^7.1.0",
     "eslint": "^9.32.0",
     "loader.js": "^4.7.0",

--- a/tests/my-v1-app/package.json
+++ b/tests/my-v1-app/package.json
@@ -73,7 +73,7 @@
     "ember-resolver": "^13.1.1",
     "ember-source": "~6.6.0",
     "ember-template-imports": "^4.3.0",
-    "ember-template-lint": "7.9.1",
+    "ember-template-lint": "7.9.2",
     "ember-test-selectors": "^7.1.0",
     "embroider-css-modules": "^3.0.0",
     "eslint": "^9.32.0",

--- a/tests/my-v2-addon/package.json
+++ b/tests/my-v2-addon/package.json
@@ -81,7 +81,7 @@
     "concurrently": "^9.2.0",
     "ember-modifier": "^4.2.2",
     "ember-source": "~6.6.0",
-    "ember-template-lint": "^7.9.1",
+    "ember-template-lint": "^7.9.2",
     "eslint": "^9.32.0",
     "postcss": "^8.5.6",
     "prettier": "^3.6.2",

--- a/tests/my-v2-app/package.json
+++ b/tests/my-v2-app/package.json
@@ -80,7 +80,7 @@
     "ember-route-template": "^1.0.3",
     "ember-source": "~6.6.0",
     "ember-template-imports": "^4.3.0",
-    "ember-template-lint": "^7.9.1",
+    "ember-template-lint": "^7.9.2",
     "ember-test-selectors": "^7.1.0",
     "embroider-css-modules": "^3.0.0",
     "eslint": "^9.32.0",


### PR DESCRIPTION
We can use autofix to remove unused `{{! template-lint-disable }}`'s.

https://github.com/ember-template-lint/ember-template-lint/blob/v7.9.2-ember-template-lint/lib/linter.js#L118
