### PR TITLE
Ignored @typescript-eslint/no-this-alias in tests

### DIFF
--- a/.changeset/kind-eggs-smash.md
+++ b/.changeset/kind-eggs-smash.md
@@ -1,0 +1,5 @@
+---
+"@ijlee2-frontend-configs/eslint-config-ember": minor
+---
+
+Ignored @typescript-eslint/no-this-alias in tests

--- a/packages/eslint/ember/v1-addon/index.mjs
+++ b/packages/eslint/ember/v1-addon/index.mjs
@@ -125,6 +125,9 @@ export default tseslint.config(
     plugins: {
       qunit: eslintPluginQunit,
     },
+    rules: {
+      '@typescript-eslint/no-this-alias': 'off',
+    },
   },
 
   // Configuration files

--- a/packages/eslint/ember/v1-app/index.mjs
+++ b/packages/eslint/ember/v1-app/index.mjs
@@ -125,6 +125,9 @@ export default tseslint.config(
     plugins: {
       qunit: eslintPluginQunit,
     },
+    rules: {
+      '@typescript-eslint/no-this-alias': 'off',
+    },
   },
 
   // Configuration files

--- a/packages/eslint/ember/v2-app/index.mjs
+++ b/packages/eslint/ember/v2-app/index.mjs
@@ -115,6 +115,9 @@ export default tseslint.config(
     plugins: {
       qunit: eslintPluginQunit,
     },
+    rules: {
+      '@typescript-eslint/no-this-alias': 'off',
+    },
   },
 
   // Configuration files


### PR DESCRIPTION
## Background

[`ember-codemod-add-template-tags`](https://github.com/ijlee2/ember-codemod-add-template-tags) adds an alias of `this` (called `self`) due to a bug that prevents us from using `this` inside the `<template>` tag.

```diff
module('Integration | Component | hello', function (hooks) {
  hooks.beforeEach(function () {
    this.name = 'Zoey';
  });

  test('it renders', async function (assert) {
+     const self = this;
+
    await render(
-      <template><Hello @name={{this.name}} /></template>,
+      <template><Hello @name={{self.name}} /></template>,
    );

    assert.dom().hasText('Hello, Zoey!');
  });
});
```

The bug isn't fully fixed as of `ember-source@6.6.0`.