### PR TITLE
Revert "Updated pnpm to v11 (#94)"

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+auto-install-peers=false
+public-hoist-pattern[]=*eslint*
+public-hoist-pattern[]=*prettier*
+public-hoist-pattern[]=*stylelint*
+resolve-peers-from-workspace-root=false

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "sort-package-json": "^3.6.1",
     "update-workspace-root-version": "^3.0.2"
   },
-  "packageManager": "pnpm@11.1.2",
+  "packageManager": "pnpm@10.33.4",
   "engines": {
     "node": "22.* || >= 24",
     "pnpm": ">= 10"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,16 +1,3 @@
-allowBuilds:
-  core-js: false
-  unrs-resolver: false
-
-autoInstallPeers: false
-
 packages:
-  - 'packages/**'
-  - 'tests/**'
-
-publicHoistPattern:
-  - '*eslint*'
-  - '*prettier*'
-  - '*stylelint*'
-
-resolvePeersFromWorkspaceRoot: false
+  - packages/**
+  - tests/**


### PR DESCRIPTION
## Background

The `release:publish` script failed to run. I couldn't find any references to the error code `ERR_PNPM_OTP_NON_INTERACTIVE`.

```sh
🦋  error an error occurred while publishing @ijlee2-frontend-configs/eslint-config-node: ERR_PNPM_OTP_NON_INTERACTIVE undefined 
🦋  error {
🦋  error   "error": {
🦋  error     "code": "ERR_PNPM_OTP_NON_INTERACTIVE",
🦋  error     "message": "The registry requires additional authentication, but pnpm is not running in an interactive terminal"
🦋  error   }
🦋  error }
🦋  error 
🦋  error an error occurred while publishing @ijlee2-frontend-configs/eslint-config-ember: ERR_PNPM_OTP_NON_INTERACTIVE undefined 
🦋  error {
🦋  error   "error": {
🦋  error     "code": "ERR_PNPM_OTP_NON_INTERACTIVE",
🦋  error     "message": "The registry requires additional authentication, but pnpm is not running in an interactive terminal"
🦋  error   }
🦋  error }
🦋  error 
🦋  error an error occurred while publishing @ijlee2-frontend-configs/stylelint: ERR_PNPM_OTP_NON_INTERACTIVE undefined 
🦋  error {
🦋  error   "error": {
🦋  error     "code": "ERR_PNPM_OTP_NON_INTERACTIVE",
🦋  error     "message": "The registry requires additional authentication, but pnpm is not running in an interactive terminal"
🦋  error   }
🦋  error }
```