### PR TITLE
Set compilerOptions.rootDir

### DIFF
--- a/tests/my-codemod/tsconfig.build.json
+++ b/tests/my-codemod/tsconfig.build.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "declaration": false,
     "outDir": "dist",
+    "rootDir": ".",
     "types": ["@types/node", "@types/yargs"]
   },
   "include": ["bin", "src"],

--- a/tests/my-codemod/tsconfig.json
+++ b/tests/my-codemod/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "declaration": false,
     "outDir": "dist-for-testing",
+    "rootDir": ".",
     "types": ["@types/node", "@types/yargs"]
   },
   "include": ["bin", "src", "tests"],

--- a/tests/my-v1-addon/tsconfig.build.json
+++ b/tests/my-v1-addon/tsconfig.build.json
@@ -9,6 +9,7 @@
       "my-v1-addon/test-support/*": ["./addon-test-support/*"],
       "*": ["./types/*"]
     },
+    "rootDir": ".",
     "types": ["@glint/ember-tsc/types", "@types/qunit", "ember-source/types"]
   },
   "include": ["addon/**/*", "addon-test-support/**/*"]

--- a/tests/my-v1-addon/tsconfig.json
+++ b/tests/my-v1-addon/tsconfig.json
@@ -13,6 +13,7 @@
       "my-v1-addon/test-support/*": ["./addon-test-support/*"],
       "*": ["./types/*"]
     },
+    "rootDir": ".",
     "types": ["@glint/ember-tsc/types", "@types/qunit", "ember-source/types"]
   },
   "include": [

--- a/tests/my-v1-app/tsconfig.json
+++ b/tests/my-v1-app/tsconfig.json
@@ -6,6 +6,7 @@
       "my-v1-app/*": ["./app/*"],
       "*": ["./types/*"]
     },
+    "rootDir": ".",
     "types": ["@glint/ember-tsc/types", "@types/qunit", "ember-source/types"]
   },
   "include": ["app/**/*", "tests/**/*", "types/**/*"]

--- a/tests/my-v2-app/tsconfig.json
+++ b/tests/my-v2-app/tsconfig.json
@@ -6,6 +6,7 @@
       "my-v2-app/*": ["./app/*"],
       "*": ["./types/*"]
     },
+    "rootDir": ".",
     "types": ["@glint/ember-tsc/types", "@types/qunit", "ember-source/types"]
   },
   "include": ["app/**/*", "tests/**/*", "types/**/*"]


### PR DESCRIPTION
## Background

Patches #101. The value of `compilerOptions.rootDir` depends on the project, so I explicitly noted what's currently needed.
