### PR TITLE
Replaced eslint-plugin-sort-class-members with eslint-plugin-perfectionist

### DIFF
--- a/.changeset/early-chicken-wish.md
+++ b/.changeset/early-chicken-wish.md
@@ -1,0 +1,11 @@
+---
+"@ijlee2-frontend-configs/eslint-config-ember": minor
+"@ijlee2-frontend-configs/eslint-config-node": minor
+"my-v1-app": patch
+"my-codemod": patch
+"my-v1-addon": patch
+"my-v2-addon": patch
+"my-v2-app": patch
+---
+
+Replaced eslint-plugin-sort-class-members with eslint-plugin-perfectionist

--- a/packages/eslint/ember/package.json
+++ b/packages/eslint/ember/package.json
@@ -36,7 +36,6 @@
     "eslint-plugin-perfectionist": "^5.10.0",
     "eslint-plugin-qunit": "^8.2.6",
     "eslint-plugin-simple-import-sort": "^13.0.0",
-    "eslint-plugin-sort-class-members": "^1.22.1",
     "globals": "^17.7.0",
     "typescript-eslint": "^8.63.0"
   },

--- a/packages/eslint/ember/shared/index.mjs
+++ b/packages/eslint/ember/shared/index.mjs
@@ -4,110 +4,76 @@ export const customRules = {
     'import-x/no-duplicates': 'error',
     'import-x/no-unresolved': 'off',
     'max-depth': ['error', 4],
-    'simple-import-sort/imports': 'error',
-    'simple-import-sort/exports': 'error',
-    'sort-class-members/sort-class-members': [
-      2,
+    'perfectionist/sort-classes': [
+      'error',
       {
-        groups: {
-          'ember-actions': [
-            {
-              groupByDecorator: 'action',
-              sort: 'alphabetical',
-              type: 'method',
-            },
-          ],
-          'ember-controller-model': [
-            {
-              name: 'model',
-              type: 'property',
-            },
-          ],
-          'ember-controller-queryParams': [
-            {
-              name: 'queryParams',
-              type: 'property',
-            },
-          ],
-          'ember-data-decorators': [
-            {
-              groupByDecorator: 'belongsTo',
-              sort: 'alphabetical',
-              type: 'property',
-            },
-            {
-              groupByDecorator: 'hasMany',
-              sort: 'alphabetical',
-              type: 'property',
-            },
-            {
-              groupByDecorator: 'attr',
-              sort: 'alphabetical',
-              type: 'property',
-            },
-          ],
-          'ember-data-type-brand': [
-            {
-              name: 'Type',
-              type: 'property',
-            },
-          ],
-          'ember-services': [
-            {
-              groupByDecorator: 'service',
-              sort: 'alphabetical',
-              type: 'property',
-            },
-          ],
-          'ember-tracked-properties': [
-            {
-              groupByDecorator: 'tracked',
-              sort: 'alphabetical',
-              type: 'property',
-            },
-          ],
-          getters: [
-            {
-              kind: 'get',
-              sort: 'alphabetical',
-              type: 'method',
-            },
-          ],
-          methods: [
-            {
-              sort: 'alphabetical',
-              type: 'method',
-            },
-          ],
-          properties: [
-            {
-              sort: 'alphabetical',
-              type: 'property',
-            },
-          ],
-          setters: [
-            {
-              kind: 'set',
-              sort: 'alphabetical',
-              type: 'method',
-            },
-          ],
-        },
-        order: [
-          '[ember-data-type-brand]',
-          '[ember-data-decorators]',
-          '[ember-controller-model]',
-          '[ember-controller-queryParams]',
-          '[ember-services]',
-          '[ember-tracked-properties]',
-          '[properties]',
-          '[getters]',
-          '[setters]',
-          'constructor',
-          '[methods]',
-          '[ember-actions]',
+        customGroups: [
+          {
+            decoratorNamePattern: 'action',
+            groupName: 'ember-action',
+            selector: 'method',
+          },
+          {
+            elementNamePattern: 'model',
+            groupName: 'ember-controller-model',
+            selector: 'property',
+          },
+          {
+            elementNamePattern: 'queryParams',
+            groupName: 'ember-controller-queryParams',
+            selector: 'property',
+          },
+          {
+            decoratorNamePattern: 'attr',
+            groupName: 'ember-data-model-attr',
+            selector: 'property',
+          },
+          {
+            decoratorNamePattern: 'belongsTo',
+            groupName: 'ember-data-model-belongsTo',
+            selector: 'property',
+          },
+          {
+            decoratorNamePattern: 'hasMany',
+            groupName: 'ember-data-model-hasMany',
+            selector: 'property',
+          },
+          {
+            elementNamePattern: 'Type',
+            groupName: 'ember-data-model-type',
+            selector: 'property',
+          },
+          {
+            decoratorNamePattern: 'service',
+            groupName: 'ember-service',
+            selector: 'property',
+          },
+          {
+            decoratorNamePattern: 'tracked',
+            groupName: 'ember-tracked-property',
+            selector: 'property',
+          },
         ],
+        groups: [
+          'ember-data-model-type',
+          'ember-data-model-belongsTo',
+          'ember-data-model-hasMany',
+          'ember-data-model-attr',
+          'ember-controller-model',
+          'ember-controller-queryParams',
+          'ember-service',
+          'ember-tracked-property',
+          'property',
+          'get-method',
+          'set-method',
+          'constructor',
+          'method',
+          'ember-action',
+        ],
+        type: 'alphabetical',
       },
     ],
+    'simple-import-sort/imports': 'error',
+    'simple-import-sort/exports': 'error',
   },
 };

--- a/packages/eslint/ember/v1-addon/index.mjs
+++ b/packages/eslint/ember/v1-addon/index.mjs
@@ -9,7 +9,6 @@ import eslintPluginN from 'eslint-plugin-n';
 import eslintPluginPerfectionist from 'eslint-plugin-perfectionist';
 import eslintPluginQunit from 'eslint-plugin-qunit';
 import eslintPluginSimpleImportSort from 'eslint-plugin-simple-import-sort';
-import eslintPluginSortClassMembers from 'eslint-plugin-sort-class-members';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
@@ -50,7 +49,6 @@ export default defineConfig([
   eslintPluginEmber.configs.gjs,
   eslintPluginEmberTemplateLint,
   eslintPluginImportX.flatConfigs.recommended,
-  eslintPluginSortClassMembers.configs['flat/recommended'],
   eslintConfigPrettier,
   {
     plugins: {

--- a/packages/eslint/ember/v1-app/index.mjs
+++ b/packages/eslint/ember/v1-app/index.mjs
@@ -9,7 +9,6 @@ import eslintPluginN from 'eslint-plugin-n';
 import eslintPluginPerfectionist from 'eslint-plugin-perfectionist';
 import eslintPluginQunit from 'eslint-plugin-qunit';
 import eslintPluginSimpleImportSort from 'eslint-plugin-simple-import-sort';
-import eslintPluginSortClassMembers from 'eslint-plugin-sort-class-members';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
@@ -50,7 +49,6 @@ export default defineConfig([
   eslintPluginEmber.configs.gjs,
   eslintPluginEmberTemplateLint,
   eslintPluginImportX.flatConfigs.recommended,
-  eslintPluginSortClassMembers.configs['flat/recommended'],
   eslintConfigPrettier,
   {
     plugins: {

--- a/packages/eslint/ember/v2-addon/index.mjs
+++ b/packages/eslint/ember/v2-addon/index.mjs
@@ -8,7 +8,6 @@ import eslintPluginImportX from 'eslint-plugin-import-x';
 import eslintPluginN from 'eslint-plugin-n';
 import eslintPluginPerfectionist from 'eslint-plugin-perfectionist';
 import eslintPluginSimpleImportSort from 'eslint-plugin-simple-import-sort';
-import eslintPluginSortClassMembers from 'eslint-plugin-sort-class-members';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
@@ -38,7 +37,6 @@ export default defineConfig([
   eslintPluginEmber.configs.gjs,
   eslintPluginEmberTemplateLint,
   eslintPluginImportX.flatConfigs.recommended,
-  eslintPluginSortClassMembers.configs['flat/recommended'],
   eslintConfigPrettier,
   {
     plugins: {

--- a/packages/eslint/ember/v2-app/index.mjs
+++ b/packages/eslint/ember/v2-app/index.mjs
@@ -9,7 +9,6 @@ import eslintPluginN from 'eslint-plugin-n';
 import eslintPluginPerfectionist from 'eslint-plugin-perfectionist';
 import eslintPluginQunit from 'eslint-plugin-qunit';
 import eslintPluginSimpleImportSort from 'eslint-plugin-simple-import-sort';
-import eslintPluginSortClassMembers from 'eslint-plugin-sort-class-members';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
@@ -39,7 +38,6 @@ export default defineConfig([
   eslintPluginEmber.configs.gjs,
   eslintPluginEmberTemplateLint,
   eslintPluginImportX.flatConfigs.recommended,
-  eslintPluginSortClassMembers.configs['flat/recommended'],
   eslintConfigPrettier,
   {
     plugins: {

--- a/packages/eslint/node/javascript/index.mjs
+++ b/packages/eslint/node/javascript/index.mjs
@@ -6,7 +6,6 @@ import eslintPluginImportX from 'eslint-plugin-import-x';
 import eslintPluginN from 'eslint-plugin-n';
 import eslintPluginPerfectionist from 'eslint-plugin-perfectionist';
 import eslintPluginSimpleImportSort from 'eslint-plugin-simple-import-sort';
-import eslintPluginSortClassMembers from 'eslint-plugin-sort-class-members';
 import globals from 'globals';
 
 import { customRules } from '../shared/index.mjs';
@@ -29,7 +28,6 @@ export default defineConfig([
 
   eslint.configs.recommended,
   eslintPluginImportX.flatConfigs.recommended,
-  eslintPluginSortClassMembers.configs['flat/recommended'],
   eslintConfigPrettier,
   {
     plugins: {

--- a/packages/eslint/node/package.json
+++ b/packages/eslint/node/package.json
@@ -31,7 +31,6 @@
     "eslint-plugin-n": "^18.2.1",
     "eslint-plugin-perfectionist": "^5.10.0",
     "eslint-plugin-simple-import-sort": "^13.0.0",
-    "eslint-plugin-sort-class-members": "^1.22.1",
     "globals": "^17.7.0",
     "typescript-eslint": "^8.63.0"
   },

--- a/packages/eslint/node/shared/index.mjs
+++ b/packages/eslint/node/shared/index.mjs
@@ -4,47 +4,20 @@ export const customRules = {
     'import-x/no-duplicates': 'error',
     'import-x/no-unresolved': 'off',
     'max-depth': ['error', 4],
-    'simple-import-sort/imports': 'error',
-    'simple-import-sort/exports': 'error',
-    'sort-class-members/sort-class-members': [
-      2,
+    'perfectionist/sort-classes': [
+      'error',
       {
-        groups: {
-          getters: [
-            {
-              kind: 'get',
-              sort: 'alphabetical',
-              type: 'method',
-            },
-          ],
-          methods: [
-            {
-              sort: 'alphabetical',
-              type: 'method',
-            },
-          ],
-          properties: [
-            {
-              sort: 'alphabetical',
-              type: 'property',
-            },
-          ],
-          setters: [
-            {
-              kind: 'set',
-              sort: 'alphabetical',
-              type: 'method',
-            },
-          ],
-        },
-        order: [
-          '[properties]',
-          '[getters]',
-          '[setters]',
+        groups: [
+          'property',
+          'get-method',
+          'set-method',
           'constructor',
-          '[methods]',
+          'method',
         ],
+        type: 'alphabetical',
       },
     ],
+    'simple-import-sort/imports': 'error',
+    'simple-import-sort/exports': 'error',
   },
 };

--- a/packages/eslint/node/typescript/index.mjs
+++ b/packages/eslint/node/typescript/index.mjs
@@ -6,7 +6,6 @@ import eslintPluginImportX from 'eslint-plugin-import-x';
 import eslintPluginN from 'eslint-plugin-n';
 import eslintPluginPerfectionist from 'eslint-plugin-perfectionist';
 import eslintPluginSimpleImportSort from 'eslint-plugin-simple-import-sort';
-import eslintPluginSortClassMembers from 'eslint-plugin-sort-class-members';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
@@ -34,7 +33,6 @@ export default defineConfig([
 
   eslint.configs.recommended,
   eslintPluginImportX.flatConfigs.recommended,
-  eslintPluginSortClassMembers.configs['flat/recommended'],
   eslintConfigPrettier,
   {
     plugins: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,9 +81,6 @@ importers:
       eslint-plugin-simple-import-sort:
         specifier: ^13.0.0
         version: 13.0.0(eslint@10.6.0(jiti@2.7.0))
-      eslint-plugin-sort-class-members:
-        specifier: ^1.22.1
-        version: 1.22.1(eslint@10.6.0(jiti@2.7.0))
       globals:
         specifier: ^17.7.0
         version: 17.7.0
@@ -136,9 +133,6 @@ importers:
       eslint-plugin-simple-import-sort:
         specifier: ^13.0.0
         version: 13.0.0(eslint@10.6.0(jiti@2.7.0))
-      eslint-plugin-sort-class-members:
-        specifier: ^1.22.1
-        version: 1.22.1(eslint@10.6.0(jiti@2.7.0))
       globals:
         specifier: ^17.7.0
         version: 17.7.0
@@ -394,6 +388,9 @@ importers:
       '@babel/core':
         specifier: ^7.29.7
         version: 7.29.7
+      '@ember-intl/v1-compat':
+        specifier: ^1.2.1
+        version: 1.2.1(@glint/template@1.7.8)(webpack@5.108.4(postcss@8.5.16))
       '@ember/optional-features':
         specifier: ^3.0.0
         version: 3.0.0(@types/node@22.20.0)
@@ -487,6 +484,9 @@ importers:
       ember-cli-terser:
         specifier: ^4.0.2
         version: 4.0.2
+      ember-intl:
+        specifier: ^8.2.9
+        version: 8.2.9(@babel/core@7.29.7)(@ember/test-helpers@5.4.3(@babel/core@7.29.7))
       ember-load-initializers:
         specifier: ^3.0.1
         version: 3.0.1(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
@@ -4605,12 +4605,6 @@ packages:
     resolution: {integrity: sha512-McAc+/Nlvcg4byY/CABGH8kqnefWBj8s3JA2okEtz8ixbECQgU46p0HkTUKa4YS7wvgGceimlc34p1nXqbWqtA==}
     peerDependencies:
       eslint: '>=5.0.0'
-
-  eslint-plugin-sort-class-members@1.22.1:
-    resolution: {integrity: sha512-TC76+m06fjpiAYPrEcyyvvWzp1aMHNBVGROLu9ijQuPDZPWJjhNTheha4f6f7eUTWabloczLZagoZ+mb6Cv0ZQ==}
-    engines: {node: '>=4.0.0'}
-    peerDependencies:
-      eslint: '>=0.8.0'
 
   eslint-scope@5.1.1:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
@@ -10415,6 +10409,24 @@ snapshots:
 
   '@ember-data/rfc395-data@0.0.4': {}
 
+  '@ember-intl/v1-compat@1.2.1(@glint/template@1.7.8)(webpack@5.108.4(postcss@8.5.16))':
+    dependencies:
+      '@babel/core': 7.29.7
+      broccoli-caching-writer: 3.1.0
+      broccoli-funnel: 3.0.8
+      broccoli-merge-trees: 4.2.0
+      broccoli-source: 3.0.1
+      calculate-cache-key-for-tree: 2.0.0
+      ember-auto-import: 2.13.1(@glint/template@1.7.8)(webpack@5.108.4(postcss@8.5.16))
+      ember-cli-babel: 8.3.1(@babel/core@7.29.7)
+      extend: 3.0.2
+      js-yaml: 5.2.1
+      json-stable-stringify: 1.3.0
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+      - webpack
+
   '@ember-intl/v1-compat@1.2.1(@glint/template@1.7.8)(webpack@5.108.4)':
     dependencies:
       '@babel/core': 7.29.7
@@ -14652,10 +14664,6 @@ snapshots:
       requireindex: 1.2.0
 
   eslint-plugin-simple-import-sort@13.0.0(eslint@10.6.0(jiti@2.7.0)):
-    dependencies:
-      eslint: 10.6.0(jiti@2.7.0)
-
-  eslint-plugin-sort-class-members@1.22.1(eslint@10.6.0(jiti@2.7.0)):
     dependencies:
       eslint: 10.6.0(jiti@2.7.0)
 

--- a/tests/my-v1-app/app/components/welcome-1.hbs
+++ b/tests/my-v1-app/app/components/welcome-1.hbs
@@ -1,10 +1,7 @@
 <p>
-  Thanks for trying out
-  <code>create-v2-addon-repo</code>.
+  {{t "components.welcome-1.description-1" htmlSafe=true}}
 </p>
 
 <p>
-  You can use
-  <code>my-v1-app</code>
-  to document your packages.
+  {{t "components.welcome-1.description-2" htmlSafe=true}}
 </p>

--- a/tests/my-v1-app/app/components/welcome-2.gts
+++ b/tests/my-v1-app/app/components/welcome-2.gts
@@ -1,4 +1,5 @@
 import type { TOC } from '@ember/component/template-only';
+import { t } from 'ember-intl';
 
 import styles from './welcome-2.css';
 
@@ -8,9 +9,11 @@ interface Welcome2Signature {
 
 const Welcome2Component: TOC<Welcome2Signature> = <template>
   <p>
-    Visit
-    <a class={{styles.link}} href="/tests?hidepassed&nolint">/tests</a>
-    to run tests.
+    {{t
+      "components.welcome-2.description-1"
+      classForLink=styles.link
+      htmlSafe=true
+    }}
   </p>
 </template>;
 

--- a/tests/my-v1-app/app/controllers/application.ts
+++ b/tests/my-v1-app/app/controllers/application.ts
@@ -1,7 +1,43 @@
 import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { type Registry as Services, service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 import styles from './application.css';
 
+type Locale = 'de-de' | 'en-us';
+
+type Model = {};
+
 export default class ApplicationController extends Controller {
+  model: Model | null = null;
+
+  queryParams = ['locale'];
+
+  @service declare intl: Services['intl'];
+
+  @tracked locale: Locale | null = null;
+
   styles = styles;
+
+  get todaysDate(): string {
+    if (this.intl.primaryLocale === 'de-de') {
+      return '30.06.2025';
+    }
+
+    return '06/30/2025';
+  }
+
+  @action doSomething(): void {
+    // TODO
+  }
+
+  @action logTodaysDate(): void {
+    this.log(this.todaysDate);
+  }
+
+  // eslint-disable-next-line sort-class-members/sort-class-members
+  private log(message: string): void {
+    console.log(message);
+  }
 }

--- a/tests/my-v1-app/app/controllers/application.ts
+++ b/tests/my-v1-app/app/controllers/application.ts
@@ -36,7 +36,7 @@ export default class ApplicationController extends Controller {
     this.log(this.todaysDate);
   }
 
-  // eslint-disable-next-line sort-class-members/sort-class-members
+  // eslint-disable-next-line perfectionist/sort-classes
   private log(message: string): void {
     console.log(message);
   }

--- a/tests/my-v1-app/app/models/user.ts
+++ b/tests/my-v1-app/app/models/user.ts
@@ -1,0 +1,45 @@
+import { type Registry as Services, service } from '@ember/service';
+import Model, {
+  type AsyncHasMany,
+  attr,
+  belongsTo,
+  hasMany,
+  // @ts-expect-error: Dependency not installed
+} from '@ember-data/model';
+import { cached } from '@glimmer/tracking';
+// @ts-expect-error: Dependency not installed
+import type { Type } from '@warp-drive/core-types/symbols';
+
+export default class User extends Model {
+  declare [Type]: 'user';
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+  @belongsTo('user', { async: false, inverse: null })
+  declare bestFriend: null | User;
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+  @hasMany('user', { async: true, inverse: null })
+  declare friends: AsyncHasMany<User>;
+
+  @attr declare firstName: string;
+
+  @attr declare lastName: string;
+
+  @service declare intl: Services['intl'];
+
+  @cached get fullName(): string {
+    return this.firstName + ' ' + this.lastName;
+  }
+
+  get greeting(): string {
+    if (this.intl.primaryLocale === 'de-de') {
+      return `Hallo, ${this.firstName}!`;
+    }
+
+    return `Hello, ${this.firstName}!`;
+  }
+
+  sayHi(): void {
+    alert(this.greeting);
+  }
+}

--- a/tests/my-v1-app/app/routes/application.ts
+++ b/tests/my-v1-app/app/routes/application.ts
@@ -1,0 +1,14 @@
+import Route from '@ember/routing/route';
+import { type Registry as Services, service } from '@ember/service';
+
+export default class ApplicationRoute extends Route {
+  @service declare intl: Services['intl'];
+
+  beforeModel(): void {
+    this.setupIntl();
+  }
+
+  private setupIntl(): void {
+    this.intl.setLocale(['en-us']);
+  }
+}

--- a/tests/my-v1-app/app/routes/application.ts
+++ b/tests/my-v1-app/app/routes/application.ts
@@ -1,8 +1,13 @@
+import type Owner from '@ember/owner';
 import Route from '@ember/routing/route';
 import { type Registry as Services, service } from '@ember/service';
 
 export default class ApplicationRoute extends Route {
   @service declare intl: Services['intl'];
+
+  constructor(owner: Owner) {
+    super(owner);
+  }
 
   beforeModel(): void {
     this.setupIntl();

--- a/tests/my-v1-app/app/templates/index.hbs
+++ b/tests/my-v1-app/app/templates/index.hbs
@@ -1,6 +1,6 @@
 <div>
   <h1>
-    Welcome!
+    {{t "routes.index.page-title"}}
   </h1>
 
   <div>

--- a/tests/my-v1-app/app/templates/my-v2-addon.hbs
+++ b/tests/my-v1-app/app/templates/my-v2-addon.hbs
@@ -1,6 +1,6 @@
 <div>
   <h1>
-    Welcome!
+    {{t "routes.my-v2-addon.page-title"}}
   </h1>
 
   <div>

--- a/tests/my-v1-app/package.json
+++ b/tests/my-v1-app/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",
+    "@ember-intl/v1-compat": "^1.2.1",
     "@ember/optional-features": "^3.0.0",
     "@ember/string": "^4.0.1",
     "@ember/test-helpers": "^5.4.3",
@@ -59,6 +60,7 @@
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
+    "ember-intl": "^8.2.9",
     "ember-load-initializers": "^3.0.1",
     "ember-modifier": "^4.3.0",
     "ember-page-title": "^9.0.3",

--- a/tests/my-v1-app/tests/integration/components/welcome-1-test.ts
+++ b/tests/my-v1-app/tests/integration/components/welcome-1-test.ts
@@ -1,10 +1,12 @@
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import { setupIntl } from 'ember-intl/test-support';
 import { setupRenderingTest } from 'my-v1-app/tests/helpers';
 import { module, test } from 'qunit';
 
 module('Integration | Component | welcome-1', function (hooks) {
   setupRenderingTest(hooks);
+  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     await render(

--- a/tests/my-v1-app/tests/integration/components/welcome-2-test.gts
+++ b/tests/my-v1-app/tests/integration/components/welcome-2-test.gts
@@ -1,10 +1,12 @@
 import { render } from '@ember/test-helpers';
+import { setupIntl } from 'ember-intl/test-support';
 import Welcome2 from 'my-v1-app/components/welcome-2';
 import { setupRenderingTest } from 'my-v1-app/tests/helpers';
 import { module, test } from 'qunit';
 
 module('Integration | Component | welcome-2', function (hooks) {
   setupRenderingTest(hooks);
+  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     await render(<template><Welcome2 /></template>);

--- a/tests/my-v1-app/translations/en-us.json
+++ b/tests/my-v1-app/translations/en-us.json
@@ -1,0 +1,7 @@
+{
+  "components.welcome-1.description-1": "Thanks for trying out <code>create-v2-addon-repo</code>.",
+  "components.welcome-1.description-2": "You can use <code>my-v1-app</code> to document your packages.",
+  "components.welcome-2.description-1": "Visit <a class={classForLink} href=\"/tests?hidepassed&nolint\">/tests</a> to run tests.",
+  "routes.index.page-title": "Welcome!",
+  "routes.my-v2-addon.page-title": "Welcome!"
+}


### PR DESCRIPTION
## Background

In #103, I introduced `eslint-plugin-perfectionist` to replace [`eslint-plugin-typescript-sort-keys`](https://github.com/infctr/eslint-plugin-typescript-sort-keys), which had been unmaintained. We can use it to replace [`eslint-plugin-sort-class-members`](https://github.com/bryanrsmith/eslint-plugin-sort-class-members) too.
