### PR TITLE
Addressed breaking changes in `@changesets/get-github-info@1.0.0`

### DIFF
--- a/.changeset/eager-buttons-tickle.md
+++ b/.changeset/eager-buttons-tickle.md
@@ -1,0 +1,5 @@
+---
+"@ijlee2-frontend-configs/changesets": major
+---
+
+Addressed breaking changes in `@changesets/get-github-info@1.0.0`

--- a/packages/changesets/index.mjs
+++ b/packages/changesets/index.mjs
@@ -1,17 +1,26 @@
-import { getInfo } from '@changesets/get-github-info';
+import { getCommitInfo } from '@changesets/get-github-info';
 
 async function extractInformation({ changeset, repo }) {
-  const { links: info } = await getInfo({
+  const info = await getCommitInfo({
     commit: changeset.commit,
     repo,
   });
 
-  const contributor = info.user ? `(${info.user})` : undefined;
-  const link = info.pull ?? info.commit ?? undefined;
   const summary = (changeset.summary ?? '').split(/\r?\n/)[0].trim();
 
+  if (info === undefined) {
+    return {
+      contributor: undefined,
+      link: undefined,
+      summary,
+    };
+  }
+
+  const contributor = info.author?.markdownLink;
+  const link = info.pull?.markdownLink ?? info.commit.markdownLink;
+
   return {
-    contributor,
+    contributor: contributor ? `(${contributor})` : undefined,
     link,
     summary,
   };


### PR DESCRIPTION
## Background

Patches #110.


## References

- https://github.com/changesets/changesets/blob/%40changesets/get-github-info%401.0.0/packages/get-github-info/src/get-commit-info.ts#L9-L25
- https://github.com/changesets/changesets/blob/%40changesets/get-github-info%401.0.0/packages/get-github-info/CHANGELOG.md#100