### PR TITLE
Disallowed creating tags for private packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,5 +1,8 @@
 {
   "access": "public",
   "changelog": "./formatter.mjs",
-  "privatePackages": true
+  "privatePackages": {
+    "tag": false,
+    "version": true
+  }
 }

--- a/.changeset/many-toes-hang.md
+++ b/.changeset/many-toes-hang.md
@@ -1,0 +1,5 @@
+---
+"@ijlee2-frontend-configs/changesets": patch
+---
+
+Updated README to show versioning private packages only

--- a/packages/changesets/README.md
+++ b/packages/changesets/README.md
@@ -21,13 +21,16 @@ import getFormatter from '@ijlee2-frontend-configs/changesets';
 export default getFormatter('<your-github-handle>/<your-repo-name>');
 ```
 
-Then, provide the relative path to this file in [`.changeset/config.json`. See [`changesets` documentation](https://changesets.dev/guide/config) for more information.
+Then, set the `changelog` key in your [`.changeset/config.json`. See [`changesets` documentation](https://changesets.dev/guide/config) for more information.
 
 ```json
 {
   "access": "public",
   "changelog": "./formatter.mjs",
-  "privatePackages": true
+  "privatePackages": {
+    "tag": false,
+    "version": true
+  }
 }
 ```
 


### PR DESCRIPTION
## Background

Patches #110 to prevent creating tags for private packages.

```sh
❯ pnpm release:publish --otp <...>
$ changeset publish --otp <...>
┌  🦋 changeset v3.0.0
│
●  These packages will be published as they were not found in the registry:
│  @ijlee2-frontend-configs/changesets@3.0.0
│  @ijlee2-frontend-configs/eslint-config-ember@4.2.2
│  @ijlee2-frontend-configs/eslint-config-node@4.2.2
│  @ijlee2-frontend-configs/prettier@3.3.3
│  3 packages are already published.
│
◇  Successfully published:
@ijlee2-frontend-configs/changesets@3.0.0
@ijlee2-frontend-configs/eslint-config-ember@4.2.2
@ijlee2-frontend-configs/eslint-config-node@4.2.2
@ijlee2-frontend-configs/prettier@3.3.3
│
◇  Created git tags:
- my-codemod@1.3.4
- my-v1-addon@1.3.4
- my-v1-app@1.3.4
- my-v2-addon@1.3.4
- my-v2-app@1.3.4
```